### PR TITLE
Bringing in the pluggable inference providers and some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ venv*
 *.speed
 
 __pycache__
+/allycat.iml
+/.idea/

--- a/4_query.ipynb
+++ b/4_query.ipynb
@@ -149,44 +149,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ LLM run environment:  local_ollama\n",
-      "✅ Using LLM model :  qwen3:0.6b\n"
-     ]
-    }
-   ],
-   "source": [
-    "from llama_index.llms.ollama import Ollama\n",
-    "from llama_index.llms.replicate import Replicate\n",
-    "\n",
-    "# Setup LLM\n",
-    "if MY_CONFIG.LLM_RUN_ENV == 'replicate':\n",
-    "    llm = Replicate(\n",
-    "        model=MY_CONFIG.LLM_MODEL,\n",
-    "        temperature=0.1\n",
-    "    )\n",
-    "    if os.getenv('REPLICATE_API_TOKEN'):\n",
-    "        print(\"✅ Found REPLICATE_API_TOKEN\")    \n",
-    "    else:   \n",
-    "        raise ValueError(\"❌ Please set the REPLICATE_API_TOKEN environment variable in .env file.\")\n",
-    "elif MY_CONFIG.LLM_RUN_ENV == 'local_ollama':\n",
-    "    llm = Ollama(\n",
-    "        model= MY_CONFIG.LLM_MODEL,\n",
-    "        request_timeout=30.0,\n",
-    "        temperature=0.1\n",
-    "    )\n",
-    "else:\n",
-    "    raise ValueError(\"❌ Invalid LLM run environment. Please set it to 'replicate' or 'local_ollama'.\")\n",
-    "print(\"✅ LLM run environment: \", MY_CONFIG.LLM_RUN_ENV)    \n",
-    "print(\"✅ Using LLM model : \", MY_CONFIG.LLM_MODEL)\n",
-    "Settings.llm = llm"
-   ]
+   "outputs": [],
+   "source": "from llama_index.llms.ollama import Ollama\nfrom llama_index.llms.replicate import Replicate\nfrom llama_index.llms.openai_like import OpenAILike\n\n# Setup LLM\nif MY_CONFIG.LLM_RUN_ENV == 'replicate':\n    llm = Replicate(\n        model=MY_CONFIG.LLM_MODEL,\n        temperature=0.1\n    )\n    if os.getenv('REPLICATE_API_TOKEN'):\n        print(\"✅ Found REPLICATE_API_TOKEN\")    \n    else:   \n        raise ValueError(\"❌ Please set the REPLICATE_API_TOKEN environment variable in .env file.\")\nelif MY_CONFIG.LLM_RUN_ENV == 'local_ollama':\n    llm = Ollama(\n        model= MY_CONFIG.LLM_MODEL,\n        request_timeout=30.0,\n        temperature=0.1\n    )\nelif MY_CONFIG.LLM_RUN_ENV == 'vllm':\n    vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']\n    llm = OpenAILike(\n        model=vllm_config['model'],\n        api_key=vllm_config['api_key'],\n        api_base=vllm_config['api_base'],\n        temperature=vllm_config.get('temperature', 0.1),\n        context_window=vllm_config.get('context_window', 8192),\n        is_chat_model=vllm_config.get('is_chat_model', True)\n    )\nelse:\n    raise ValueError(\"❌ Invalid LLM run environment. Please set it to 'replicate', 'local_ollama', or 'vllm'.\")\nprint(\"✅ LLM run environment: \", MY_CONFIG.LLM_RUN_ENV)    \nprint(\"✅ Using LLM model : \", MY_CONFIG.LLM_MODEL)\nSettings.llm = llm"
   },
   {
    "cell_type": "markdown",

--- a/4_query.py
+++ b/4_query.py
@@ -12,6 +12,7 @@ from llama_index.core import VectorStoreIndex
 from llama_index.llms.replicate import Replicate
 from dotenv import load_dotenv
 from llama_index.llms.ollama import Ollama
+from llama_index.llms.openai_like import OpenAILike
 import query_utils
 import time
 
@@ -70,8 +71,18 @@ elif MY_CONFIG.LLM_RUN_ENV == 'local_ollama':
         request_timeout=30.0,
         temperature=0.1
     )
+elif MY_CONFIG.LLM_RUN_ENV == 'vllm':
+    vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+    llm = OpenAILike(
+        model=vllm_config['model'],
+        api_key=vllm_config['api_key'],
+        api_base=vllm_config['api_base'],
+        temperature=vllm_config.get('temperature', 0.1),
+        context_window=vllm_config.get('context_window', 8192),
+        is_chat_model=vllm_config.get('is_chat_model', True)
+    )
 else:
-    raise ValueError("❌ Invalid LLM run environment. Please set it to 'replicate' or 'local_ollama'.")
+    raise ValueError("❌ Invalid LLM run environment. Please set it to 'replicate', 'local_ollama', or 'vllm'.")
 print("✅ LLM run environment: ", MY_CONFIG.LLM_RUN_ENV)    
 print("✅ Using LLM model : ", MY_CONFIG.LLM_MODEL)
 Settings.llm = llm

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # AllyCat
 
-**AllyCat** is full stack, open source chatbot that uses GenAI LLMs to answer questions about your website. It is simple by design and will run on your laptop or server. 
+**AllyCat** is a full-stack, open source chatbot with **pluggable LLM providers** that uses GenAI to answer questions about your website. It is simple by design and scales from laptop to production server. 
 
 ## Why?
 
@@ -28,7 +28,36 @@ AllyCat also includes web scraping tools that extract data from your website (or
 5. Supports multiple vector databases.
    - **Currently:** [Milvus](https://milvus.io/) or [Weaviate](https://weaviate.io)
 6. End User and New Contributor Friendly.
-   - **Currently:** Run locally with [Ollama](https://ollama.com/), or as-a-service on [Replicate](https://replicate.com)
+   - **Currently:** Run locally with [Ollama](https://ollama.com/) or [vLLM](https://docs.vllm.ai/en/latest/index.html), or as-a-service on [Replicate](https://replicate.com)
+7. Easily switch between inference providers - **Pluggable LLM Provider Architecture** - 
+   - **Local:** [Ollama](https://ollama.com/) (lightweight, CPU/GPU)
+   - **High-Performance:** [vLLM](https://docs.vllm.ai/) (optimized GPU inference)  
+   - **Cloud:** [Replicate](https://replicate.com) (managed service)
+   - **Extensible:** Add any LLM provider with a [LlamaIndex implementation](https://docs.llamaindex.ai/en/stable/module_guides/models/llms/)
+8. Supports multiple vector databases
+   - **Currently:** [Milvus](https://milvus.io/) or [Weaviate](https://weaviate.io)
+9. Simple Configuration-Driven Setup
+   - **One-line provider switching:** Change `ACTIVE_PROVIDER` in config file
+   - **No code changes required:** All provider settings centralized in `my_config.py`
+   - **Beginner-friendly:** Works with local Ollama or cloud services
+
+## 🔌 Pluggable Architecture
+
+AllyCat uses a **pluggable provider system** that makes it easy to:
+
+- **Switch LLM providers** by changing one config setting
+- **Add new providers** that have LlamaIndex implementations  
+- **Configure per-provider settings** without touching code
+- **Scale from laptop to production** using the same codebase
+
+**Supported Providers:**
+| Provider | Best For | Setup |
+|----------|----------|-------|
+| [Ollama](https://ollama.com/) | Local development, learning | `pip install` + model download |
+| [vLLM](https://docs.vllm.ai/) | High-performance inference | `pip install vllm` + GPU |
+| [Replicate](https://replicate.com) | Cloud inference, scaling | API key setup |
+
+**Adding New Providers:** Any LLM with a [LlamaIndex integration](https://docs.llamaindex.ai/en/stable/module_guides/models/llms/) can be added to the factory pattern in `llm_service.py`.
 
 ## ⚡️⚡️Quickstart ⚡️⚡️
 

--- a/app.py
+++ b/app.py
@@ -14,8 +14,6 @@ from llama_index.core import VectorStoreIndex, StorageContext
 from llama_index.vector_stores.milvus import MilvusVectorStore
 from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 from llama_index.core import Settings
-from llama_index.llms.replicate import Replicate
-from llama_index.llms.ollama import Ollama
 from my_config import MY_CONFIG
 import query_utils
 
@@ -40,29 +38,9 @@ def initialize():
     # raise Exception ("init exception test") # debug
     
     try:
-        ## embedding model
-        Settings.embed_model = HuggingFaceEmbedding(
-            model_name = MY_CONFIG.EMBEDDING_MODEL
-        )
-        print("✅ Using embedding model: ", MY_CONFIG.EMBEDDING_MODEL)
-        
-        # Setup LLM
-        if MY_CONFIG.LLM_RUN_ENV == 'replicate':
-            llm = Replicate(
-                model=MY_CONFIG.LLM_MODEL,
-                temperature=0.1
-            )
-        elif MY_CONFIG.LLM_RUN_ENV == 'local_ollama':
-            llm = Ollama(
-                model= MY_CONFIG.LLM_MODEL,
-                request_timeout=30.0,
-                temperature=0.1
-            )
-        else:
-            raise ValueError("❌ Invalid LLM run environment. Please set it to 'replicate' or 'local_ollama'.")
-        print("✅ LLM run environment: ", MY_CONFIG.LLM_RUN_ENV)    
-        print("✅ Using LLM model : ", MY_CONFIG.LLM_MODEL)
-        Settings.llm = llm
+        # Initialize LLM service (handles all providers)
+        from llm_service import initialize_llm_service
+        initialize_llm_service()
         
         # Initialize Milvus vector store
         vector_store = MilvusVectorStore(
@@ -79,7 +57,6 @@ def initialize():
         print ("✅ Loaded index from vector db:", MY_CONFIG.DB_URI )
 
         logging.info("Successfully initialized LLM and vector database")
-    
         initialization_complete = True
     except Exception as e:
         initialization_complete = False

--- a/docs/customizing-allycat.md
+++ b/docs/customizing-allycat.md
@@ -1,66 +1,202 @@
 # Customizing Allycat
 
-- [1 - To try a different LLM with Ollama](#1---to-try-a-different-llm-with-ollama)
-- [2 - Trying a different model with Replicate](#2---trying-a-different-model-with-replicate)
+AllyCat uses a **pluggable provider architecture** that makes it easy to switch between different LLM providers by changing a single configuration setting. All provider configurations are centralized in `my_config.py`, so you never need to modify code files.
+
+## Quick Provider Switching
+
+To switch providers, simply change the `ACTIVE_PROVIDER` setting in [my_config.py](../my_config.py):
+
+```python
+MY_CONFIG.ACTIVE_PROVIDER = 'ollama'    # or 'vllm' or 'replicate'
+```
+
+## Available Providers
+
+- [1 - Ollama (Local, CPU/GPU)](#1---to-try-a-different-llm-with-ollama)
+- [2 - Replicate (Cloud Service)](#2---trying-a-different-model-with-replicate)
+- [3 - vLLM (High-Performance Local)](#3---trying-vllm-for-high-performance-inference)
+- [4 - Embedding Models](#4---trying-various-embedding-models)
 
 
 ## 1 - To try a different LLM with Ollama
 
-**Edit file [my_config.py](../my_config.py)**
+**Step 1: Set Ollama as Active Provider**
+
+Edit file [my_config.py](../my_config.py) and set:
 
 ```python
-MY_CONFIG.LLM_RUN_ENV = 'local_ollama'
-MY_CONFIG.LLM_MODEL = "gemma3:1b" 
-``` 
-
-Change the model to something else:
-
-```python
-MY_CONFIG.LLM_MODEL = "qwen3:1.7b"
+MY_CONFIG.ACTIVE_PROVIDER = 'ollama'
 ```
 
-**Download the ollama model**
+**Step 2: Customize Ollama Model**
+
+The Ollama configuration is in the `LLM_PROVIDERS` section:
+
+```python
+'ollama': {
+    'model': 'gemma3:1b',  # Change this to your desired model
+    'request_timeout': 30.0,
+    'temperature': 0.1
+}
+```
+
+To try a different model, change the model name:
+
+```python
+'ollama': {
+    'model': 'qwen3:1.7b',  # Updated model
+    'request_timeout': 30.0,
+    'temperature': 0.1
+}
+```
+
+**Step 3: Download the Ollama Model**
 
 ```bash
-ollama  pull qwen3:1.7b
+ollama pull qwen3:1.7b
 ```
 
 Verify the model is ready:
 
 ```bash
-ollama   list
+ollama list
 ```
 
-Make sure the model is listed.  Now the model is ready to be used.
+Make sure the model is listed. Now the model is ready to be used.
 
-Now you can run the query:
+**Step 4: Run Your Query**
 
 ```bash
-python   4_query.py
+python 4_query.py
 ```
 
 ## 2 - Trying a different model with Replicate
 
-**Edit file [my_config.py](../my_config.py)**
+**Step 1: Set Replicate as Active Provider**
+
+Edit file [my_config.py](../my_config.py) and set:
 
 ```python
-MY_CONFIG.LLM_RUN_ENV = 'replicate'
-MY_CONFIG.LLM_MODEL = "meta/meta-llama-3-8b-instruct"
+MY_CONFIG.ACTIVE_PROVIDER = 'replicate'
 ```
 
-Change the model to the desired model:
+**Step 2: Customize Replicate Model**
+
+The Replicate configuration is in the `LLM_PROVIDERS` section:
 
 ```python
-MY_CONFIG.LLM_MODEL = "ibm-granite/granite-3.2-8b-instruct
+'replicate': {
+    'model': 'meta/meta-llama-3-8b-instruct',  # Change this to your desired model
+    'temperature': 0.1
+}
 ```
 
-Now you can run the query:
+To try a different model, change the model name:
+
+```python
+'replicate': {
+    'model': 'ibm-granite/granite-3.2-8b-instruct',  # Updated model
+    'temperature': 0.1
+}
+```
+
+**Step 3: Ensure API Token is Set**
+
+Make sure you have your Replicate API token in your `.env` file:
 
 ```bash
-python   4_query.py
+REPLICATE_API_TOKEN=your_token_here
 ```
 
-## 3 - Trying various embedding models
+**Step 4: Run Your Query**
+
+```bash
+python 4_query.py
+```
+
+## 3 - Trying a different model with vLLM 
+
+
+**Step 1: Install vLLM**
+
+See the [vLLM Installation Guide](https://docs.vllm.ai/en/latest/getting_started/installation.html) for detailed instructions.
+
+Quick install:
+```bash
+pip install vllm
+```
+
+**Step 2: Set vLLM as Active Provider**
+
+Edit file [my_config.py](../my_config.py) and set:
+
+```python
+MY_CONFIG.ACTIVE_PROVIDER = 'vllm'
+```
+
+**Step 3: Customize vLLM Configuration**
+
+The vLLM configuration is in the `LLM_PROVIDERS` section:
+
+```python
+'vllm': {
+    'model': 'RedHatAI/gemma-3-4b-it-quantized.w4a16',  # Change to your desired model
+    'api_key': 'fake',  # vLLM doesn't require real API key
+    'api_base': 'http://localhost:8000/v1',  # vLLM server URL
+    'temperature': 0.1,
+    'context_window': 8192,  # Should match your --max-model-len setting or default model context length
+    'is_chat_model': True
+}
+```
+
+To try a different model, update the configuration:
+
+```python
+'vllm': {
+    'model': 'Qwen/Qwen2.5-1.5B-Instruct',  # Different model
+    'api_key': 'fake',
+    'api_base': 'http://localhost:8000/v1',
+    'temperature': 0.1,
+    'context_window': 120000,  # Should match your --max-model-len setting or default model context length
+    'is_chat_model': True
+}
+```
+*Note* The model name you provide in this section must match the model name you pass to `vllm serve`
+
+
+**Step 4: Start vLLM Server**
+
+Before running AllyCat, start the vLLM server:
+
+```bash
+# Start vLLM server with your model
+vllm serve RedHatAI/gemma-3-4b-it-quantized.w4a16 --max-model-len 8192
+
+# Server will be available at http://localhost:8000
+```
+
+or
+
+```bash
+# Start vLLM server with your model
+vllm serve Qwen/Qwen2.5-1.5B-Instruct 
+
+# Server will be available at http://localhost:8000
+```
+
+**Step 5: Run Your Query**
+
+```bash
+python 4_query.py
+```
+
+**Key Points:**
+- vLLM requires GPU for best performance
+- The `context_window` setting should match your `--max-model-len` parameter
+- vLLM server must be running before starting AllyCat
+- AllyCat connects via OpenAI-compatible API
+
+## 4 - Trying various embedding models
 
 **Edit file [my_config.py](../my_config.py)** and change these lines:
 

--- a/docs/running-allycat.md
+++ b/docs/running-allycat.md
@@ -88,19 +88,28 @@ python   3_save_to_vector_db.py
 
 For this step, we need an LLM.
 
-We have two options for running an LLM.
+We have three options for running an LLM:
 
-1. Running an open LLM locally using Ollama.  This is FREE and doesn't require any API access (default option)
-2. Using a service like [Replicate](https://replicate.com)
+1. **Local Ollama** - Running an open LLM locally using Ollama. This is FREE and doesn't require any API access (default option)
+2. **vLLM** - High-performance inference server for running models locally with better throughput
+3. **Replicate** - Cloud-based inference service
 
+### Configuration Overview
 
-### 4.1 - Option 1: local Ollama (default) 
-
-File: [my_config.py](../my_config.py):
+All LLM configuration is now centralized in [my_config.py](../my_config.py). You only need to change the `ACTIVE_PROVIDER` setting:
 
 ```python
-MY_CONFIG.LLM_RUN_ENV = 'local_ollama'
-MY_CONFIG.LLM_MODEL = "gemma3:1b" 
+MY_CONFIG.ACTIVE_PROVIDER = 'ollama'    # or 'vllm' or 'replicate'
+```
+
+The application will automatically use the correct provider configuration without needing to modify any code files.
+
+### 4.1 - Option 1: Local Ollama (default) 
+
+Set in [my_config.py](../my_config.py):
+
+```python
+MY_CONFIG.ACTIVE_PROVIDER = 'ollama'
 ```
 
 - If you are running the Allycat docker image, then Ollama is already installed.  
@@ -118,16 +127,46 @@ ollama   pull gemma3:1b
 ollama  list
 ```
 
-Sample output might look like:
+### 4.2 - Option 2: vLLM (high performance)
 
-
-### 4.2 - Option 2: For using Replicate
-
-File: [my_config.py](../my_config.py):
+Set in [my_config.py](../my_config.py):
 
 ```python
-MY_CONFIG.LLM_RUN_ENV = 'replicate'
-MY_CONFIG.LLM_MODEL = "meta/meta-llama-3-8b-instruct"
+MY_CONFIG.ACTIVE_PROVIDER = 'vllm'
+```
+
+**Installing vLLM:**
+
+For installation instructions, see the [vLLM Installation Guide](https://docs.vllm.ai/en/latest/getting_started/installation.html).
+
+Quick install for most systems:
+```bash
+pip install vllm
+```
+
+**Running vLLM Server:**
+
+Before running AllyChat, start the vLLM server:
+
+```bash
+# Example: Start vLLM server with the configured model
+vllm serve RedHatAI/gemma-3-4b-it-quantized.w4a16 --max-model-len 8192
+
+# Server will be available at http://localhost:8000
+```
+
+**Key Points:**
+- vLLM provides higher throughput than Ollama
+- Requires GPU for best performance
+- AllyChat connects to vLLM via OpenAI-compatible API
+- The `context_window` setting in config should match your `--max-model-len` parameter
+
+### 4.3 - Option 3: Replicate (cloud service)
+
+Set in [my_config.py](../my_config.py):
+
+```python
+MY_CONFIG.ACTIVE_PROVIDER = 'replicate'
 ```
 
 Also make sure that you have completed [replicate setup](running-natively.md#step-4-replicate-setup-optional)

--- a/docs/running-natively.md
+++ b/docs/running-natively.md
@@ -5,8 +5,11 @@ This guide will show you how to run and develop with AllyCat natively.
 ## Prerequisites: 
 
 - [Python 3.11 Environment](https://www.python.org/downloads/) or [Anaconda](https://www.anaconda.com/docs/getting-started/getting-started) Environment
-- Use [Ollama](https://ollama.com) if planning to run LLM locally
-- Use [Replicate](https://replicate.com) if you want to run your LLM in the cloud
+
+**Choose one LLM provider:**
+- Use [Ollama](https://ollama.com) for local LLM (easy setup, CPU/GPU)
+- Use [vLLM](https://docs.vllm.ai/) for high-performance local inference (requires GPU)
+- Use [Replicate](https://replicate.com) for cloud-based LLM service
 
 ## Step-1: Clone this repo
 
@@ -64,6 +67,19 @@ Once you have an API token, add it to the project like this:
 - Copy the file `env.sample.txt` into `.env`  (note the dot in the beginning of the filename)
 - Add your token to `REPLICATE_API_TOKEN` in the .env file.  Save this file.
 
-## Step-5: Continue to workflow
+## Step-5: vLLM Setup (Optional)
+
+For high-performance inference, you can use vLLM instead of Ollama.
+
+**Installation:**
+```bash
+pip install vllm
+```
+
+For detailed installation instructions, see the [vLLM Installation Guide](https://docs.vllm.ai/en/latest/getting_started/installation.html).
+
+**Note:** vLLM requires GPU for optimal performance. The server setup is covered in the [main workflow](running-allycat.md#42---option-2-vllm-high-performance).
+
+## Step-6: Continue to workflow
 
 Proceed to [run Allycat](running-allycat.md)

--- a/llm_service.py
+++ b/llm_service.py
@@ -1,0 +1,56 @@
+import importlib
+from llama_index.core import Settings
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+from my_config import MY_CONFIG
+
+class ProviderFactory:
+    """Factory class for creating LLM providers dynamically"""
+    
+    PROVIDERS = {
+        'ollama': ('llama_index.llms.ollama', 'Ollama'),
+        'replicate': ('llama_index.llms.replicate', 'Replicate'),
+        'vllm': ('llama_index.llms.openai_like', 'OpenAILike')
+    }
+    
+    @classmethod
+    def create_llm(cls, provider_name, config):
+        """Create LLM instance dynamically based on provider name and config"""
+        if provider_name not in cls.PROVIDERS:
+            raise ValueError(f"❌ Unsupported provider: {provider_name}")
+        
+        module_name, class_name = cls.PROVIDERS[provider_name]
+        
+        try:
+            # Dynamic import
+            module = importlib.import_module(module_name)
+            llm_class = getattr(module, class_name)
+            
+            # Filter out None values to make parameters optional
+            filtered_config = {k: v for k, v in config.items() if v is not None}
+            
+            # Create instance with filtered config
+            return llm_class(**filtered_config)
+        except ImportError as e:
+            raise ValueError(f"❌ Failed to import {module_name}: {e}")
+        except Exception as e:
+            raise ValueError(f"❌ Failed to create {provider_name} LLM: {e}")
+
+def initialize_llm_service():
+    """Initialize LLM service using pluggable provider architecture"""
+    
+    # Configure embedding (same for all providers)
+    Settings.embed_model = HuggingFaceEmbedding(model_name=MY_CONFIG.EMBEDDING_MODEL)
+    print("✅ Using embedding model:", MY_CONFIG.EMBEDDING_MODEL)
+    
+    # Get active provider configuration
+    provider_name = MY_CONFIG.ACTIVE_PROVIDER
+    provider_config = MY_CONFIG.LLM_PROVIDERS[provider_name]
+    
+    # Create LLM instance dynamically
+    llm = ProviderFactory.create_llm(provider_name, provider_config)
+    
+    Settings.llm = llm
+    print("✅ LLM provider:", provider_name)    
+    print("✅ Using LLM model:", provider_config.get('model'))
+    
+    return llm

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,12 +16,12 @@ milvus-lite==2.4.11
 # weaviate-client
 
 
-
 ## --- llama-index
 llama-index
 llama-index-embeddings-huggingface
 llama-index-llms-replicate
 llama-index-llms-ollama
+llama-index-llms-openai-like
 llama-index-vector-stores-milvus==0.5.0
 
 ## --- flask
@@ -36,3 +36,8 @@ ipykernel
 
 # UI - chainlit
 chainlit
+
+## --- testing
+pytest>=7.0.0
+pytest-flask>=1.2.0
+pytest-asyncio>=0.21.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,150 @@
+# AllyCat Test Suite
+
+This directory contains the comprehensive test suite for AllyCat's pluggable LLM provider architecture.
+
+## Test Structure
+
+### Provider-Agnostic Tests
+- `test_app.py` - Flask web application integration tests
+- `test_query.py` - CLI query functionality tests  
+- `test_config.py` - Configuration validation tests
+- `test_llm_service.py` - Pluggable provider factory tests
+
+### Provider-Specific Tests
+- `test_ollama_integration.py` - Ollama-specific functionality tests
+- `test_vllm_integration.py` - vLLM-specific functionality tests
+
+### Test Infrastructure
+- `conftest.py` - Shared fixtures and provider-agnostic test helpers
+
+## Prerequisites for Running Tests
+
+### 1. Install Dependencies
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Stop Running Applications
+**IMPORTANT**: Stop any running instances of AllyCat before running tests:
+- Stop `app.py` (Flask web server)
+- Stop `4_query.py` (CLI interface)
+- Any other processes using the configured LLM provider
+
+This prevents resource conflicts and GPU memory issues.
+
+### 3. Provider-Specific Requirements
+
+#### For Ollama Tests (`ACTIVE_PROVIDER='ollama'`)
+- Ollama server running: `ollama serve`
+- Required model available: `ollama pull gemma3:1b` (or your configured model)
+- Sufficient system memory for model loading
+
+#### For vLLM Tests (`ACTIVE_PROVIDER='vllm'`)
+- vLLM server running: `vllm serve MODEL_NAME --max-model-len 8192`
+- Server accessible at configured `api_base` (default: `http://localhost:8000/v1`)
+- Sufficient GPU memory available (tests load actual models)
+- No other processes using GPU memory
+
+#### For Replicate Tests (`ACTIVE_PROVIDER='replicate'`)
+- Valid `REPLICATE_API_TOKEN` environment variable set
+- Active internet connection
+- API quota available
+
+### 4. Vector Database
+- Milvus Lite database with populated test data
+- Database accessible at configured location
+- Embedding model available for loading
+
+## Running Tests
+
+### Run All Tests
+```bash
+python -m pytest tests/ -v
+```
+
+### Run Specific Test Categories
+```bash
+# Provider-agnostic tests only
+python -m pytest tests/test_app.py tests/test_query.py tests/test_config.py tests/test_llm_service.py -v
+
+# Current provider integration tests only
+python -m pytest tests/ -k "not (ollama_integration or vllm_integration)" -v
+
+# Specific provider tests
+python -m pytest tests/test_ollama_integration.py -v  # Only if ACTIVE_PROVIDER='ollama'
+python -m pytest tests/test_vllm_integration.py -v   # Only if ACTIVE_PROVIDER='vllm'
+```
+
+### Run Tests with Timing
+```bash
+# Exclude slow tests
+python -m pytest tests/ -v -m "not slow"
+
+# Include all tests with timing
+python -m pytest tests/ -v --durations=10
+```
+
+## Test Behavior
+
+### Conditional Execution
+- Provider-specific tests automatically skip when not using that provider
+- Tests use `MY_CONFIG.ACTIVE_PROVIDER` to determine which provider to test
+- No mocking - tests validate actual service integration
+
+### Real Service Testing
+These tests intentionally **do not use mocking** for LLM services. They:
+- Load actual models into memory
+- Connect to real provider services  
+- Test true end-to-end functionality
+- Validate production-ready integrations
+
+This approach provides confidence that the system works with real services but requires:
+- Actual provider services running
+- Sufficient system resources
+- Proper configuration
+
+### GPU Memory Considerations
+- vLLM tests require significant GPU memory
+- Stop other GPU processes before running tests
+- Consider running tests on systems with adequate GPU resources
+- Tests will fail with CUDA out-of-memory if insufficient GPU memory
+
+## Troubleshooting
+
+### Common Issues
+
+**CUDA Out of Memory**
+- Stop running AllyCat applications
+- Stop other GPU processes: `nvidia-smi` to check
+- Reduce model size or context window in configuration
+- Run tests on system with more GPU memory
+
+**Provider Connection Errors**
+- Verify provider service is running and accessible
+- Check configuration in `my_config.py`
+- Validate API keys and endpoints
+- Check network connectivity for cloud providers
+
+**Test Failures with "DID NOT RAISE"**
+- Ensure provider services are stopped before running factory tests
+- Check that test configuration matches actual provider requirements
+
+**Import or Module Errors**
+- Install all dependencies: `pip install -r requirements.txt`
+- Ensure Python path includes AllyCat modules
+- Check for conflicting package versions
+
+### Debug Mode
+Run with verbose output and no capture:
+```bash
+python -m pytest tests/ -v -s --tb=long
+```
+
+## Test Configuration
+
+Tests use the same configuration as the main application:
+- `MY_CONFIG.ACTIVE_PROVIDER` determines which provider to test
+- `MY_CONFIG.LLM_PROVIDERS` provides provider-specific settings
+- `MY_CONFIG.EMBEDDING_MODEL` for embedding model configuration
+
+Modify `my_config.py` to test different provider configurations.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,290 @@
+"""
+Pytest configuration and shared fixtures for AllyCat test suite.
+
+Provides provider-agnostic testing infrastructure that works with
+the pluggable LLM provider architecture.
+"""
+
+import pytest
+import os
+import sys
+import time
+from unittest.mock import patch, MagicMock
+
+# Add parent directory to path to import AllyCat modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from my_config import MY_CONFIG
+
+
+def pytest_configure(config):
+    """Configure pytest with custom markers."""
+    config.addinivalue_line(
+        "markers", "ollama: mark test as requiring Ollama provider"
+    )
+    config.addinivalue_line(
+        "markers", "vllm: mark test as requiring vLLM provider"
+    )
+    config.addinivalue_line(
+        "markers", "replicate: mark test as requiring Replicate provider"
+    )
+    config.addinivalue_line(
+        "markers", "slow: mark test as slow running"
+    )
+    config.addinivalue_line(
+        "markers", "integration: mark test as integration test"
+    )
+
+
+@pytest.fixture(scope="session")
+def active_provider():
+    """Get the currently active LLM provider from configuration."""
+    return MY_CONFIG.ACTIVE_PROVIDER
+
+
+@pytest.fixture(scope="session")
+def provider_config(active_provider):
+    """Get the configuration for the active provider."""
+    return MY_CONFIG.LLM_PROVIDERS[active_provider]
+
+
+@pytest.fixture(scope="session")
+def is_ollama_active(active_provider):
+    """Check if Ollama is the active provider."""
+    return active_provider == 'ollama'
+
+
+@pytest.fixture(scope="session")
+def is_vllm_active(active_provider):
+    """Check if vLLM is the active provider.""" 
+    return active_provider == 'vllm'
+
+
+@pytest.fixture(scope="session")
+def is_replicate_active(active_provider):
+    """Check if Replicate is the active provider."""
+    return active_provider == 'replicate'
+
+
+@pytest.fixture
+def mock_config():
+    """Provide a mock configuration for testing."""
+    class MockConfig:
+        def __init__(self):
+            self.ACTIVE_PROVIDER = 'ollama'
+            self.LLM_PROVIDERS = {
+                'ollama': {
+                    'model': 'gemma3:1b',
+                    'request_timeout': 30.0,
+                    'temperature': 0.1
+                },
+                'vllm': {
+                    'model': 'test-model',
+                    'api_key': 'fake',
+                    'api_base': 'http://localhost:8000/v1',
+                    'temperature': 0.1,
+                    'context_window': 8192,
+                    'is_chat_model': True
+                },
+                'replicate': {
+                    'model': 'meta/test-model',
+                    'temperature': 0.1
+                }
+            }
+            self.EMBEDDING_MODEL = 'ibm-granite/granite-embedding-30m-english'
+            self.EMBEDDING_LENGTH = 384
+            self.DB_URI = 'test.db'
+            self.COLLECTION_NAME = 'test_collection'
+    
+    return MockConfig()
+
+
+@pytest.fixture
+def llm_service():
+    """Initialize LLM service for testing."""
+    try:
+        from llm_service import initialize_llm_service
+        initialize_llm_service()
+        print(f"✅ LLM service initialized with provider: {MY_CONFIG.ACTIVE_PROVIDER}")
+        return True
+    except Exception as e:
+        pytest.skip(f"LLM service initialization failed: {e}")
+
+
+@pytest.fixture
+def mock_vector_store():
+    """Provide a mock vector store for testing."""
+    mock_store = MagicMock()
+    mock_store.query.return_value = MagicMock()
+    mock_store.query.return_value.response = "Mock response from vector store"
+    return mock_store
+
+
+@pytest.fixture
+def flask_app():
+    """Create a Flask app instance for testing."""
+    # Avoid importing app module at test collection time
+    # Import only when needed in the test
+    return None
+
+
+@pytest.fixture
+def flask_client(flask_app):
+    """Create a Flask test client."""
+    if flask_app is None:
+        pytest.skip("Flask app not available")
+    return flask_app.test_client()
+
+
+# Skip decorators for provider-specific tests
+skip_if_not_ollama = pytest.mark.skipif(
+    MY_CONFIG.ACTIVE_PROVIDER != 'ollama',
+    reason="Test requires Ollama provider"
+)
+
+skip_if_not_vllm = pytest.mark.skipif(
+    MY_CONFIG.ACTIVE_PROVIDER != 'vllm', 
+    reason="Test requires vLLM provider"
+)
+
+skip_if_not_replicate = pytest.mark.skipif(
+    MY_CONFIG.ACTIVE_PROVIDER != 'replicate',
+    reason="Test requires Replicate provider"
+)
+
+
+def pytest_runtest_setup(item):
+    """Setup hook that runs before each test."""
+    # Skip tests based on provider markers
+    if item.get_closest_marker("ollama") and MY_CONFIG.ACTIVE_PROVIDER != 'ollama':
+        pytest.skip("Test requires Ollama provider")
+    
+    if item.get_closest_marker("vllm") and MY_CONFIG.ACTIVE_PROVIDER != 'vllm':
+        pytest.skip("Test requires vLLM provider")
+    
+    if item.get_closest_marker("replicate") and MY_CONFIG.ACTIVE_PROVIDER != 'replicate':
+        pytest.skip("Test requires Replicate provider")
+
+
+class ProviderTestHelper:
+    """Helper class for provider-agnostic testing."""
+    
+    @staticmethod
+    def get_test_query():
+        """Get a simple test query that should work with any provider."""
+        return "Hello, how are you?"
+    
+    @staticmethod
+    def get_rag_test_query():
+        """Get a query that should use RAG context."""
+        return "What is AI Alliance?"
+    
+    @staticmethod
+    def get_math_query():
+        """Get a math query for testing basic reasoning."""
+        return "What is 2+2?"
+    
+    @staticmethod
+    def validate_response(response_text):
+        """Validate that a response looks reasonable."""
+        if not response_text:
+            return False
+        
+        # Basic validation - should be non-empty string
+        if not isinstance(response_text, str):
+            return False
+            
+        # Should have some content
+        if len(response_text.strip()) < 3:
+            return False
+            
+        return True
+    
+    @staticmethod
+    def validate_rag_response(response_text):
+        """Validate that a response contains RAG-relevant content."""
+        if not ProviderTestHelper.validate_response(response_text):
+            return False
+            
+        # Should contain relevant keywords for AI Alliance
+        response_lower = response_text.lower()
+        relevant_keywords = ['alliance', 'ai', 'artificial', 'intelligence', 'collaboration']
+        
+        return any(keyword in response_lower for keyword in relevant_keywords)
+    
+    @staticmethod
+    def extract_timing_from_response(response_text):
+        """Extract timing information from response if present."""
+        import re
+        
+        # Look for pattern like "time taken: X.X secs"
+        timing_pattern = r'time taken:\s*(\d+\.?\d*)\s*secs?'
+        match = re.search(timing_pattern, response_text, re.IGNORECASE)
+        
+        if match:
+            return float(match.group(1))
+        return None
+
+
+@pytest.fixture
+def provider_helper():
+    """Provide the ProviderTestHelper for tests."""
+    return ProviderTestHelper
+
+
+# Timeout fixtures for different test types
+@pytest.fixture
+def short_timeout():
+    """Short timeout for quick tests."""
+    return 10.0
+
+
+@pytest.fixture  
+def medium_timeout():
+    """Medium timeout for normal tests."""
+    return 30.0
+
+
+@pytest.fixture
+def long_timeout():
+    """Long timeout for slow/integration tests."""
+    return 120.0
+
+
+def pytest_collection_modifyitems(config, items):
+    """Modify test collection to add markers automatically."""
+    for item in items:
+        # Add slow marker to performance tests
+        if "performance" in item.name.lower():
+            item.add_marker(pytest.mark.slow)
+        
+        # Add integration marker to integration tests    
+        if "integration" in item.name.lower():
+            item.add_marker(pytest.mark.integration)
+        
+        # Add provider markers based on test file names
+        if "ollama" in str(item.fspath):
+            item.add_marker(pytest.mark.ollama)
+        elif "vllm" in str(item.fspath):
+            item.add_marker(pytest.mark.vllm)
+        elif "replicate" in str(item.fspath):
+            item.add_marker(pytest.mark.replicate)
+
+
+# Environment variable support for test configuration
+@pytest.fixture(scope="session", autouse=True)
+def setup_test_environment():
+    """Setup test environment variables and configuration."""
+    # Allow overriding provider for tests via environment variable
+    test_provider = os.environ.get('ALLYCAT_TEST_PROVIDER')
+    if test_provider:
+        original_provider = MY_CONFIG.ACTIVE_PROVIDER
+        MY_CONFIG.ACTIVE_PROVIDER = test_provider
+        print(f"Test environment: Using provider {test_provider}")
+        
+        yield
+        
+        # Restore original provider
+        MY_CONFIG.ACTIVE_PROVIDER = original_provider
+    else:
+        yield

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,272 @@
+"""
+Integration tests for Flask app.py functionality.
+
+Tests the web application's pluggable provider integration, initialization,
+and chat endpoint behavior with provider-agnostic approach.
+
+Prerequisites:
+- Active LLM provider properly configured (see MY_CONFIG.ACTIVE_PROVIDER)
+- Vector database populated with test data
+- Provider-specific services running (e.g., Ollama, vLLM server, Replicate API key)
+"""
+
+import pytest
+import json
+import sys
+import os
+import time
+from unittest.mock import patch, MagicMock
+
+# Add parent directory to path to import AllyCat modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from my_config import MY_CONFIG
+
+
+@pytest.fixture
+def app():
+    """Create test Flask app instance using current provider configuration."""
+    # Import app after ensuring provider is configured
+    from app import app as flask_app
+    flask_app.config['TESTING'] = True
+    
+    # Log which provider we're testing with
+    print(f"Testing with provider: {MY_CONFIG.ACTIVE_PROVIDER}")
+    
+    yield flask_app
+
+
+@pytest.fixture
+def client(app):
+    """Create test client."""
+    return app.test_client()
+
+
+class TestAppInitialization:
+    """Test Flask app initialization with pluggable provider system."""
+    
+    def test_app_initialization_success(self, app):
+        """Test that app initializes successfully with current provider."""
+        # Import the app module
+        import app as app_module
+        
+        # Call initialize (should succeed with properly configured provider)
+        try:
+            app_module.initialize()
+            assert app_module.initialization_complete == True
+            print(f"✅ App initialization successful with {MY_CONFIG.ACTIVE_PROVIDER}")
+        except Exception as e:
+            pytest.fail(f"App initialization failed with {MY_CONFIG.ACTIVE_PROVIDER}: {e}")
+    
+    def test_app_vector_index_creation(self, app):
+        """Test that vector index is created during initialization."""
+        import app as app_module
+        
+        # Initialize the app
+        app_module.initialize()
+        
+        # Check that vector index exists
+        assert app_module.vector_index is not None
+        assert hasattr(app_module.vector_index, 'as_query_engine')
+        print("✅ Vector index created successfully")
+    
+    def test_app_llm_settings_applied(self, app):
+        """Test that LLM settings are correctly applied via llm_service."""
+        import app as app_module
+        from llama_index.core import Settings
+        
+        # Initialize the app
+        app_module.initialize()
+        
+        # Check that Settings.llm is configured
+        assert Settings.llm is not None
+        print(f"✅ LLM settings applied to llama-index via {MY_CONFIG.ACTIVE_PROVIDER}")
+
+
+class TestAppRoutes:
+    """Test Flask app routes and responses."""
+    
+    def test_index_route(self, client):
+        """Test the main index route."""
+        response = client.get('/')
+        
+        assert response.status_code == 200
+        assert b'html' in response.data.lower()
+        print("✅ Index route working")
+    
+    def test_index_route_with_init_error(self, app, client):
+        """Test index route behavior when initialization fails."""
+        # Set an init error
+        app.config['INIT_ERROR'] = 'Test initialization error'
+        
+        response = client.get('/')
+        
+        assert response.status_code == 200
+        # Should contain error message in response
+        assert b'error' in response.data.lower() or b'init' in response.data.lower()
+        print("✅ Index route handles init errors")
+
+
+class TestChatEndpoint:
+    """Test the /chat endpoint with current provider integration."""
+    
+    def test_chat_endpoint_basic(self, client, provider_helper):
+        """Test basic chat functionality."""
+        test_message = provider_helper.get_test_query()
+        
+        response = client.post('/chat', 
+                             json={'message': test_message},
+                             content_type='application/json')
+        
+        assert response.status_code == 200
+        
+        data = json.loads(response.data)
+        assert 'response' in data
+        assert provider_helper.validate_response(data['response'])
+        assert 'time taken' in data['response']  # Should include timing
+        print(f"✅ Basic chat working with {MY_CONFIG.ACTIVE_PROVIDER}: {data['response'][:100]}...")
+    
+    def test_chat_endpoint_with_rag_query(self, client, provider_helper):
+        """Test chat with a query that should use RAG."""
+        test_message = provider_helper.get_rag_test_query()
+        
+        response = client.post('/chat',
+                             json={'message': test_message},
+                             content_type='application/json')
+        
+        assert response.status_code == 200
+        
+        data = json.loads(response.data)
+        assert 'response' in data
+        assert len(data['response']) > 10  # Should be substantial response
+        
+        # Response should contain relevant information
+        assert provider_helper.validate_rag_response(data['response'])
+        print(f"✅ RAG query working with {MY_CONFIG.ACTIVE_PROVIDER}: {data['response'][:150]}...")
+    
+    def test_chat_endpoint_empty_message(self, client):
+        """Test chat endpoint with empty message."""
+        response = client.post('/chat',
+                             json={'message': ''},
+                             content_type='application/json')
+        
+        assert response.status_code == 200
+        
+        data = json.loads(response.data)
+        assert 'response' in data
+        # Should handle empty message gracefully
+        assert len(data['response']) > 0
+        print("✅ Empty message handling working")
+    
+    def test_chat_endpoint_missing_message(self, client):
+        """Test chat endpoint with missing message field."""
+        response = client.post('/chat',
+                             json={},
+                             content_type='application/json')
+        
+        assert response.status_code == 200
+        
+        data = json.loads(response.data)
+        assert 'response' in data
+        # Should handle missing message gracefully
+        print("✅ Missing message handling working")
+    
+    def test_chat_endpoint_invalid_json(self, client):
+        """Test chat endpoint with invalid JSON."""
+        response = client.post('/chat',
+                             data='invalid json',
+                             content_type='application/json')
+        
+        # Should return 400 for invalid JSON
+        assert response.status_code == 400
+        print("✅ Invalid JSON handling working")
+    
+    @pytest.mark.slow
+    def test_chat_endpoint_performance(self, client, provider_helper, medium_timeout):
+        """Test that chat endpoint responds within reasonable time."""
+        test_message = provider_helper.get_math_query()
+        
+        start_time = time.time()
+        response = client.post('/chat',
+                             json={'message': test_message},
+                             content_type='application/json')
+        end_time = time.time()
+        
+        assert response.status_code == 200
+        
+        # Should respond within configured timeout
+        response_time = end_time - start_time
+        assert response_time < medium_timeout
+        
+        data = json.loads(response.data)
+        # Response should include timing information
+        assert 'time taken' in data['response']
+        print(f"✅ Performance test passed with {MY_CONFIG.ACTIVE_PROVIDER}: {response_time:.1f}s response time")
+
+
+class TestAppErrorHandling:
+    """Test error handling in the Flask app."""
+    
+    def test_app_handles_llm_errors(self, client):
+        """Test app behavior when LLM encounters errors."""
+        # Mock the get_llm_response function to return an error message
+        # (simulating the internal error handling within get_llm_response)
+        with patch('app.get_llm_response') as mock_response:
+            mock_response.return_value = "Sorry, I encountered an error while processing your request: Test LLM error"
+            
+            response = client.post('/chat',
+                                 json={'message': 'test'},
+                                 content_type='application/json')
+            
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            assert 'response' in data
+            assert 'error' in data['response'].lower()
+            print("✅ LLM error handling working")
+    
+    def test_app_handles_vector_store_errors(self, app):
+        """Test app behavior when vector store is unavailable."""
+        # This would require mocking the vector store initialization
+        # For now, just verify the app can handle initialization errors
+        import app as app_module
+        
+        # If initialization failed, app should still serve basic routes
+        if not app_module.initialization_complete:
+            with app.test_client() as client:
+                response = client.get('/')
+                assert response.status_code == 200
+                print("✅ Vector store error handling working")
+        else:
+            print("✅ Vector store available, skipping error test")
+
+
+class TestAppConfiguration:
+    """Test app configuration and settings."""
+    
+    def test_app_uses_config_settings(self, app):
+        """Test that app uses MY_CONFIG settings correctly."""
+        import app as app_module
+        from llama_index.core import Settings
+        
+        app_module.initialize()
+        
+        # Verify settings were applied
+        assert Settings.llm is not None
+        print(f"✅ App configuration integration working with {MY_CONFIG.ACTIVE_PROVIDER}")
+    
+    def test_app_embedding_model_setup(self, app):
+        """Test that embedding model is configured correctly."""
+        import app as app_module
+        from llama_index.core import Settings
+        
+        app_module.initialize()
+        
+        # Check that embedding model is set
+        assert Settings.embed_model is not None
+        assert hasattr(Settings.embed_model, 'model_name')
+        print("✅ Embedding model configuration working")
+
+
+if __name__ == "__main__":
+    # Run tests with verbose output
+    pytest.main([__file__, "-v"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,297 @@
+"""
+Tests for AllyCat configuration system and pluggable provider architecture.
+
+Tests configuration loading, validation, and provider switching functionality.
+"""
+
+import pytest
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+# Add parent directory to path to import AllyCat modules  
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from my_config import MY_CONFIG
+
+
+class TestConfigurationLoading:
+    """Test basic configuration loading and validation."""
+    
+    def test_config_has_required_attributes(self):
+        """Test that MY_CONFIG has all required attributes."""
+        required_attrs = [
+            'ACTIVE_PROVIDER',
+            'LLM_PROVIDERS', 
+            'EMBEDDING_MODEL',
+            'EMBEDDING_LENGTH',
+            'DB_URI',
+            'COLLECTION_NAME'
+        ]
+        
+        for attr in required_attrs:
+            assert hasattr(MY_CONFIG, attr), f"MY_CONFIG missing required attribute: {attr}"
+        
+        print("✅ All required configuration attributes present")
+    
+    def test_active_provider_is_valid(self):
+        """Test that ACTIVE_PROVIDER is set to a valid value."""
+        valid_providers = ['ollama', 'vllm', 'replicate']
+        
+        assert MY_CONFIG.ACTIVE_PROVIDER in valid_providers, \
+            f"ACTIVE_PROVIDER '{MY_CONFIG.ACTIVE_PROVIDER}' not in {valid_providers}"
+        
+        print(f"✅ Active provider '{MY_CONFIG.ACTIVE_PROVIDER}' is valid")
+    
+    def test_llm_providers_structure(self):
+        """Test that LLM_PROVIDERS has correct structure."""
+        assert isinstance(MY_CONFIG.LLM_PROVIDERS, dict), "LLM_PROVIDERS should be a dictionary"
+        
+        expected_providers = ['ollama', 'vllm', 'replicate']
+        for provider in expected_providers:
+            assert provider in MY_CONFIG.LLM_PROVIDERS, f"Missing provider: {provider}"
+            assert isinstance(MY_CONFIG.LLM_PROVIDERS[provider], dict), f"Provider {provider} config should be dict"
+        
+        print("✅ LLM_PROVIDERS structure is correct")
+    
+    def test_active_provider_has_config(self):
+        """Test that the active provider has configuration."""
+        active_provider = MY_CONFIG.ACTIVE_PROVIDER
+        
+        assert active_provider in MY_CONFIG.LLM_PROVIDERS, \
+            f"Active provider '{active_provider}' not found in LLM_PROVIDERS"
+        
+        provider_config = MY_CONFIG.LLM_PROVIDERS[active_provider]
+        assert 'model' in provider_config, f"Provider {active_provider} missing 'model' config"
+        
+        print(f"✅ Active provider '{active_provider}' has valid configuration")
+
+
+class TestProviderConfigurations:
+    """Test individual provider configurations."""
+    
+    def test_ollama_config_structure(self):
+        """Test Ollama provider configuration structure."""
+        ollama_config = MY_CONFIG.LLM_PROVIDERS['ollama']
+        
+        required_keys = ['model', 'request_timeout', 'temperature']
+        for key in required_keys:
+            assert key in ollama_config, f"Ollama config missing key: {key}"
+        
+        # Validate types
+        assert isinstance(ollama_config['model'], str), "Ollama model should be string"
+        assert isinstance(ollama_config['request_timeout'], (int, float)), "request_timeout should be numeric"
+        assert isinstance(ollama_config['temperature'], (int, float)), "temperature should be numeric"
+        
+        print("✅ Ollama configuration structure valid")
+    
+    def test_vllm_config_structure(self):
+        """Test vLLM provider configuration structure."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        
+        required_keys = ['model', 'api_key', 'api_base', 'temperature', 'context_window', 'is_chat_model']
+        for key in required_keys:
+            assert key in vllm_config, f"vLLM config missing key: {key}"
+        
+        # Validate types
+        assert isinstance(vllm_config['model'], str), "vLLM model should be string"
+        assert isinstance(vllm_config['api_key'], str), "api_key should be string"
+        assert isinstance(vllm_config['api_base'], str), "api_base should be string"
+        assert isinstance(vllm_config['temperature'], (int, float)), "temperature should be numeric"
+        assert isinstance(vllm_config['context_window'], int), "context_window should be integer"
+        assert isinstance(vllm_config['is_chat_model'], bool), "is_chat_model should be boolean"
+        
+        # Validate URL format
+        assert vllm_config['api_base'].startswith('http'), "api_base should be valid URL"
+        
+        print("✅ vLLM configuration structure valid")
+    
+    def test_replicate_config_structure(self):
+        """Test Replicate provider configuration structure."""
+        replicate_config = MY_CONFIG.LLM_PROVIDERS['replicate']
+        
+        required_keys = ['model', 'temperature']
+        for key in required_keys:
+            assert key in replicate_config, f"Replicate config missing key: {key}"
+        
+        # Validate types
+        assert isinstance(replicate_config['model'], str), "Replicate model should be string"
+        assert isinstance(replicate_config['temperature'], (int, float)), "temperature should be numeric"
+        
+        # Validate model format (should contain '/')
+        assert '/' in replicate_config['model'], "Replicate model should be in format 'owner/model'"
+        
+        print("✅ Replicate configuration structure valid")
+
+
+class TestLegacyCompatibility:
+    """Test backwards compatibility with legacy configuration."""
+    
+    def test_legacy_attributes_exist(self):
+        """Test that legacy configuration attributes still exist."""
+        # These are used for backwards compatibility
+        legacy_attrs = ['LLM_RUN_ENV', 'LLM_MODEL']
+        
+        for attr in legacy_attrs:
+            assert hasattr(MY_CONFIG, attr), f"Legacy attribute {attr} missing"
+        
+        print("✅ Legacy configuration attributes present")
+    
+    def test_legacy_env_mapping(self):
+        """Test that LLM_RUN_ENV maps correctly to ACTIVE_PROVIDER."""
+        active_provider = MY_CONFIG.ACTIVE_PROVIDER
+        legacy_env = MY_CONFIG.LLM_RUN_ENV
+        
+        # Check the mapping logic from my_config.py
+        if active_provider == 'ollama':
+            assert legacy_env == 'local_ollama', "Ollama should map to 'local_ollama'"
+        elif active_provider == 'replicate':
+            assert legacy_env == 'replicate', "Replicate should map to 'replicate'"
+        elif active_provider == 'vllm':
+            assert legacy_env == 'vllm', "vLLM should map to 'vllm'"
+        
+        print(f"✅ Legacy mapping: {active_provider} -> {legacy_env}")
+    
+    def test_legacy_model_mapping(self):
+        """Test that LLM_MODEL maps to active provider's model."""
+        active_provider = MY_CONFIG.ACTIVE_PROVIDER
+        legacy_model = MY_CONFIG.LLM_MODEL
+        provider_model = MY_CONFIG.LLM_PROVIDERS[active_provider]['model']
+        
+        assert legacy_model == provider_model, \
+            f"Legacy model '{legacy_model}' should match provider model '{provider_model}'"
+        
+        print(f"✅ Legacy model mapping: {legacy_model}")
+
+
+class TestConfigurationValidation:
+    """Test configuration validation and error cases."""
+    
+    def test_embedding_config_validation(self):
+        """Test embedding model configuration."""
+        assert isinstance(MY_CONFIG.EMBEDDING_MODEL, str), "EMBEDDING_MODEL should be string"
+        assert len(MY_CONFIG.EMBEDDING_MODEL) > 0, "EMBEDDING_MODEL should not be empty"
+        
+        assert isinstance(MY_CONFIG.EMBEDDING_LENGTH, int), "EMBEDDING_LENGTH should be integer"
+        assert MY_CONFIG.EMBEDDING_LENGTH > 0, "EMBEDDING_LENGTH should be positive"
+        
+        print("✅ Embedding configuration valid")
+    
+    def test_database_config_validation(self):
+        """Test database configuration."""
+        assert isinstance(MY_CONFIG.DB_URI, str), "DB_URI should be string"
+        assert len(MY_CONFIG.DB_URI) > 0, "DB_URI should not be empty"
+        
+        assert isinstance(MY_CONFIG.COLLECTION_NAME, str), "COLLECTION_NAME should be string"
+        assert len(MY_CONFIG.COLLECTION_NAME) > 0, "COLLECTION_NAME should not be empty"
+        
+        print("✅ Database configuration valid")
+    
+    def test_temperature_values(self):
+        """Test that temperature values are reasonable."""
+        for provider_name, provider_config in MY_CONFIG.LLM_PROVIDERS.items():
+            if 'temperature' in provider_config:
+                temp = provider_config['temperature']
+                assert 0.0 <= temp <= 2.0, f"Temperature {temp} for {provider_name} should be between 0.0 and 2.0"
+        
+        print("✅ Temperature values are reasonable")
+
+
+class TestProviderSwitching:
+    """Test provider switching functionality."""
+    
+    def test_provider_switching_simulation(self, mock_config):
+        """Test simulated provider switching."""
+        # Test switching to different providers
+        test_providers = ['ollama', 'vllm', 'replicate']
+        
+        for provider in test_providers:
+            mock_config.ACTIVE_PROVIDER = provider
+            
+            # Verify the switch
+            assert mock_config.ACTIVE_PROVIDER == provider
+            
+            # Verify provider config exists
+            assert provider in mock_config.LLM_PROVIDERS
+            
+            provider_config = mock_config.LLM_PROVIDERS[provider]
+            assert 'model' in provider_config
+            
+        print("✅ Provider switching simulation successful")
+    
+    def test_invalid_provider_detection(self, mock_config):
+        """Test that invalid providers can be detected."""
+        invalid_provider = 'nonexistent_provider'
+        mock_config.ACTIVE_PROVIDER = invalid_provider
+        
+        # This should fail validation
+        with pytest.raises(KeyError):
+            _ = mock_config.LLM_PROVIDERS[invalid_provider]
+        
+        print("✅ Invalid provider detection working")
+
+
+class TestEnvironmentVariableSupport:
+    """Test environment variable support for configuration."""
+    
+    def test_env_var_override(self):
+        """Test that environment variables can override config."""
+        # Test if ALLYCAT_TEST_PROVIDER environment variable works
+        test_provider = os.environ.get('ALLYCAT_TEST_PROVIDER')
+        
+        if test_provider:
+            # If environment variable is set, it should be used
+            print(f"✅ Environment provider override: {test_provider}")
+        else:
+            # If not set, should use default from config
+            print(f"✅ Using default provider: {MY_CONFIG.ACTIVE_PROVIDER}")
+    
+    def test_config_immutability_protection(self):
+        """Test that critical config values are protected in tests."""
+        # Save original values
+        original_provider = MY_CONFIG.ACTIVE_PROVIDER
+        original_providers = MY_CONFIG.LLM_PROVIDERS.copy()
+        
+        # Verify we can read them
+        assert original_provider is not None
+        assert len(original_providers) > 0
+        
+        print("✅ Configuration values are accessible and non-empty")
+
+
+class TestConfigurationConsistency:
+    """Test internal consistency of configuration."""
+    
+    def test_workspace_directories(self):
+        """Test workspace directory configuration."""
+        workspace_attrs = ['WORKSPACE_DIR', 'CRAWL_DIR', 'PROCESSED_DATA_DIR']
+        
+        for attr in workspace_attrs:
+            if hasattr(MY_CONFIG, attr):
+                value = getattr(MY_CONFIG, attr)
+                assert isinstance(value, str), f"{attr} should be string"
+                assert len(value) > 0, f"{attr} should not be empty"
+        
+        print("✅ Workspace directory configuration consistent")
+    
+    def test_chunking_config(self):
+        """Test chunking configuration if present."""
+        chunking_attrs = ['CHUNK_SIZE', 'CHUNK_OVERLAP']
+        
+        for attr in chunking_attrs:
+            if hasattr(MY_CONFIG, attr):
+                value = getattr(MY_CONFIG, attr)
+                assert isinstance(value, int), f"{attr} should be integer"
+                assert value > 0, f"{attr} should be positive"
+        
+        # If both exist, overlap should be less than size
+        if hasattr(MY_CONFIG, 'CHUNK_SIZE') and hasattr(MY_CONFIG, 'CHUNK_OVERLAP'):
+            assert MY_CONFIG.CHUNK_OVERLAP < MY_CONFIG.CHUNK_SIZE, \
+                "CHUNK_OVERLAP should be less than CHUNK_SIZE"
+        
+        print("✅ Chunking configuration consistent")
+
+
+if __name__ == "__main__":
+    # Run tests with verbose output
+    pytest.main([__file__, "-v"])

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,0 +1,347 @@
+"""
+Tests for AllyCat's pluggable LLM service architecture.
+
+Tests the provider factory, initialization, and provider switching functionality.
+"""
+
+import pytest
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+# Add parent directory to path to import AllyCat modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from llm_service import ProviderFactory, initialize_llm_service
+from my_config import MY_CONFIG
+from llama_index.core import Settings
+
+
+class TestProviderFactory:
+    """Test the ProviderFactory class and its methods."""
+    
+    def test_provider_factory_providers_list(self):
+        """Test that ProviderFactory knows about all supported providers."""
+        expected_providers = ['ollama', 'vllm', 'replicate']
+        
+        for provider in expected_providers:
+            assert provider in ProviderFactory.PROVIDERS, f"Provider {provider} not in factory"
+        
+        # Check provider mappings exist
+        for provider, (module_name, class_name) in ProviderFactory.PROVIDERS.items():
+            assert isinstance(module_name, str), f"Module name for {provider} should be string"
+            assert isinstance(class_name, str), f"Class name for {provider} should be string"
+            assert '.' in module_name, f"Module name {module_name} should be fully qualified"
+        
+        print("✅ ProviderFactory has all expected providers")
+    
+    def test_provider_factory_create_llm_validation(self):
+        """Test provider factory input validation."""
+        # Test invalid provider
+        with pytest.raises(ValueError) as exc_info:
+            ProviderFactory.create_llm('nonexistent_provider', {})
+        
+        assert "Unsupported provider" in str(exc_info.value)
+        print("✅ ProviderFactory validates provider names")
+    
+    def test_provider_factory_config_filtering(self):
+        """Test that factory filters None values from config."""
+        # This is a unit test that doesn't require actual LLM providers
+        test_config = {
+            'model': 'test-model',
+            'temperature': 0.1,
+            'timeout': None,  # Should be filtered out
+            'other_param': 'value'
+        }
+        
+        # Mock the import and class creation to test filtering logic
+        with patch('importlib.import_module') as mock_import:
+            mock_module = MagicMock()
+            mock_class = MagicMock()
+            mock_module.TestClass = mock_class
+            mock_import.return_value = mock_module
+            
+            # Override the provider mapping for testing
+            original_providers = ProviderFactory.PROVIDERS.copy()
+            ProviderFactory.PROVIDERS['test_provider'] = ('test.module', 'TestClass')
+            
+            try:
+                ProviderFactory.create_llm('test_provider', test_config)
+                
+                # Verify the class was called without None values
+                mock_class.assert_called_once_with(
+                    model='test-model',
+                    temperature=0.1,
+                    other_param='value'
+                )
+                print("✅ ProviderFactory filters None values from config")
+                
+            finally:
+                # Restore original providers
+                ProviderFactory.PROVIDERS = original_providers
+    
+    def test_provider_factory_import_error_handling(self):
+        """Test factory error handling for missing modules."""
+        # Test with non-existent module
+        original_providers = ProviderFactory.PROVIDERS.copy()
+        ProviderFactory.PROVIDERS['test_provider'] = ('nonexistent.module', 'TestClass')
+        
+        try:
+            with pytest.raises(ValueError) as exc_info:
+                ProviderFactory.create_llm('test_provider', {'model': 'test'})
+            
+            assert "Failed to import" in str(exc_info.value)
+            print("✅ ProviderFactory handles import errors")
+            
+        finally:
+            # Restore original providers
+            ProviderFactory.PROVIDERS = original_providers
+
+
+class TestLLMServiceInitialization:
+    """Test the initialize_llm_service function."""
+    
+    def test_initialize_llm_service_sets_embedding_model(self):
+        """Test that initialization sets up embedding model."""
+        # Save original settings
+        original_embed_model = Settings.embed_model
+        original_llm = Settings.llm
+        
+        try:
+            # Initialize service
+            initialize_llm_service()
+            
+            # Check embedding model is set
+            assert Settings.embed_model is not None
+            assert hasattr(Settings.embed_model, 'model_name')
+            assert MY_CONFIG.EMBEDDING_MODEL in Settings.embed_model.model_name
+            print("✅ LLM service sets embedding model correctly")
+            
+        finally:
+            # Restore original settings
+            Settings.embed_model = original_embed_model
+            Settings.llm = original_llm
+    
+    def test_initialize_llm_service_sets_llm(self):
+        """Test that initialization sets up LLM."""
+        # Save original settings
+        original_embed_model = Settings.embed_model  
+        original_llm = Settings.llm
+        
+        try:
+            # Initialize service
+            initialize_llm_service()
+            
+            # Check LLM is set
+            assert Settings.llm is not None
+            print(f"✅ LLM service sets LLM correctly for {MY_CONFIG.ACTIVE_PROVIDER}")
+            
+        finally:
+            # Restore original settings
+            Settings.embed_model = original_embed_model
+            Settings.llm = original_llm
+    
+    def test_initialize_llm_service_uses_active_provider(self):
+        """Test that initialization uses the configured active provider."""
+        # Save original settings
+        original_embed_model = Settings.embed_model
+        original_llm = Settings.llm
+        
+        try:
+            # Initialize service
+            llm_instance = initialize_llm_service()
+            
+            # Verify an LLM was created
+            assert llm_instance is not None
+            assert Settings.llm is not None
+            
+            # The specific type depends on the provider, but it should be set
+            print(f"✅ LLM service uses active provider {MY_CONFIG.ACTIVE_PROVIDER}")
+            
+        finally:
+            # Restore original settings
+            Settings.embed_model = original_embed_model
+            Settings.llm = original_llm
+
+
+class TestProviderSwitching:
+    """Test provider switching functionality."""
+    
+    def test_provider_config_access(self):
+        """Test accessing different provider configurations."""
+        # Test that all providers have valid configurations
+        providers = ['ollama', 'vllm', 'replicate']
+        
+        for provider in providers:
+            assert provider in MY_CONFIG.LLM_PROVIDERS, f"Provider {provider} not in config"
+            config = MY_CONFIG.LLM_PROVIDERS[provider]
+            
+            assert isinstance(config, dict), f"Config for {provider} should be dict"
+            assert 'model' in config, f"Provider {provider} missing model config"
+            assert isinstance(config['model'], str), f"Model for {provider} should be string"
+        
+        print("✅ All provider configurations are accessible")
+    
+    def test_active_provider_mapping(self):
+        """Test that active provider maps to valid configuration."""
+        active_provider = MY_CONFIG.ACTIVE_PROVIDER
+        
+        # Check active provider exists in LLM_PROVIDERS
+        assert active_provider in MY_CONFIG.LLM_PROVIDERS
+        
+        # Check configuration is valid
+        config = MY_CONFIG.LLM_PROVIDERS[active_provider]
+        assert isinstance(config, dict)
+        assert 'model' in config
+        
+        print(f"✅ Active provider {active_provider} has valid configuration")
+    
+    def test_legacy_compatibility(self):
+        """Test that legacy configuration attributes still work."""
+        # Test legacy attributes exist
+        assert hasattr(MY_CONFIG, 'LLM_RUN_ENV')
+        assert hasattr(MY_CONFIG, 'LLM_MODEL')
+        
+        # Test they map correctly to new system
+        active_provider = MY_CONFIG.ACTIVE_PROVIDER
+        legacy_model = MY_CONFIG.LLM_MODEL
+        provider_model = MY_CONFIG.LLM_PROVIDERS[active_provider]['model']
+        
+        assert legacy_model == provider_model, "Legacy model should match provider model"
+        
+        print("✅ Legacy configuration compatibility maintained")
+
+
+class TestProviderSpecificLogic:
+    """Test provider-specific logic and configurations."""
+    
+    def test_ollama_provider_config(self):
+        """Test Ollama provider configuration structure."""
+        if 'ollama' not in MY_CONFIG.LLM_PROVIDERS:
+            pytest.skip("Ollama provider not configured")
+        
+        config = MY_CONFIG.LLM_PROVIDERS['ollama']
+        
+        # Check required keys
+        required_keys = ['model', 'request_timeout', 'temperature']
+        for key in required_keys:
+            assert key in config, f"Ollama config missing {key}"
+        
+        # Check types
+        assert isinstance(config['model'], str)
+        assert isinstance(config['request_timeout'], (int, float))
+        assert isinstance(config['temperature'], (int, float))
+        
+        print("✅ Ollama provider configuration structure valid")
+    
+    def test_vllm_provider_config(self):
+        """Test vLLM provider configuration structure."""
+        if 'vllm' not in MY_CONFIG.LLM_PROVIDERS:
+            pytest.skip("vLLM provider not configured")
+        
+        config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        
+        # Check required keys
+        required_keys = ['model', 'api_key', 'api_base', 'context_window', 'is_chat_model']
+        for key in required_keys:
+            assert key in config, f"vLLM config missing {key}"
+        
+        # Check types
+        assert isinstance(config['model'], str)
+        assert isinstance(config['api_key'], str)
+        assert isinstance(config['api_base'], str)
+        assert isinstance(config['context_window'], int)
+        assert isinstance(config['is_chat_model'], bool)
+        
+        # Check URL format
+        assert config['api_base'].startswith('http'), "api_base should be valid URL"
+        
+        print("✅ vLLM provider configuration structure valid")
+    
+    def test_replicate_provider_config(self):
+        """Test Replicate provider configuration structure."""
+        if 'replicate' not in MY_CONFIG.LLM_PROVIDERS:
+            pytest.skip("Replicate provider not configured")
+        
+        config = MY_CONFIG.LLM_PROVIDERS['replicate']
+        
+        # Check required keys
+        required_keys = ['model', 'temperature']
+        for key in required_keys:
+            assert key in config, f"Replicate config missing {key}"
+        
+        # Check types
+        assert isinstance(config['model'], str)
+        assert isinstance(config['temperature'], (int, float))
+        
+        # Check model format (should contain '/')
+        assert '/' in config['model'], "Replicate model should be in 'owner/model' format"
+        
+        print("✅ Replicate provider configuration structure valid")
+
+
+class TestErrorHandling:
+    """Test error handling in the LLM service."""
+    
+    def test_invalid_provider_error(self):
+        """Test error handling for invalid provider."""
+        # This tests the factory validation
+        with pytest.raises(ValueError) as exc_info:
+            ProviderFactory.create_llm('invalid_provider', {'model': 'test'})
+        
+        assert "Unsupported provider" in str(exc_info.value)
+        print("✅ Invalid provider error handling working")
+    
+    def test_missing_config_key(self):
+        """Test error handling for missing configuration keys."""
+        # Test with empty config - this should raise an exception
+        # Use a known provider that requires specific config keys
+        with pytest.raises(Exception):  # Could be KeyError, TypeError, etc.
+            ProviderFactory.create_llm('ollama', {})  # Ollama requires 'model' key
+        
+        print("✅ Missing config key error handling working")
+
+
+class TestServiceIntegration:
+    """Test integration between different parts of the LLM service."""
+    
+    def test_service_initialization_complete_flow(self):
+        """Test complete initialization flow."""
+        # Save original settings
+        original_embed_model = Settings.embed_model
+        original_llm = Settings.llm
+        
+        try:
+            # Test complete initialization
+            result = initialize_llm_service()
+            
+            # Verify all components are set up
+            assert result is not None
+            assert Settings.embed_model is not None  
+            assert Settings.llm is not None
+            
+            print(f"✅ Complete LLM service initialization successful with {MY_CONFIG.ACTIVE_PROVIDER}")
+            
+        finally:
+            # Restore original settings
+            Settings.embed_model = original_embed_model
+            Settings.llm = original_llm
+    
+    def test_service_provider_consistency(self):
+        """Test that service uses consistent provider throughout."""
+        active_provider = MY_CONFIG.ACTIVE_PROVIDER
+        
+        # Check that the active provider is valid
+        assert active_provider in ProviderFactory.PROVIDERS
+        assert active_provider in MY_CONFIG.LLM_PROVIDERS
+        
+        # Check configuration consistency
+        provider_config = MY_CONFIG.LLM_PROVIDERS[active_provider]
+        assert 'model' in provider_config
+        
+        print(f"✅ LLM service provider consistency verified for {active_provider}")
+
+
+if __name__ == "__main__":
+    # Run tests with verbose output
+    pytest.main([__file__, "-v"])

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -1,0 +1,211 @@
+"""
+Integration tests for Ollama functionality in AllyCat.
+
+These tests validate Ollama-specific functionality when Ollama is the active provider.
+
+Prerequisites:
+- Ollama server running (ollama serve)
+- gemma3:1b model available (ollama pull gemma3:1b) 
+- MY_CONFIG.ACTIVE_PROVIDER = 'ollama'
+"""
+
+import pytest
+import os
+import sys
+import time
+from unittest.mock import patch
+
+# Add parent directory to path to import AllyCat modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from llama_index.llms.ollama import Ollama
+from llama_index.core import Settings
+from my_config import MY_CONFIG
+
+# Skip all tests in this file if Ollama is not the active provider
+pytestmark = pytest.mark.skipif(
+    MY_CONFIG.ACTIVE_PROVIDER != 'ollama',
+    reason="Ollama integration tests require ACTIVE_PROVIDER='ollama'"
+)
+
+
+class TestOllamaConnection:
+    """Test direct Ollama server connectivity and model availability."""
+    
+    def test_ollama_server_running(self):
+        """Verify Ollama server is accessible."""
+        ollama_config = MY_CONFIG.LLM_PROVIDERS['ollama']
+        llm = Ollama(model=ollama_config['model'], request_timeout=10.0)
+        
+        # Simple test query to verify connection
+        response = llm.complete("Hello")
+        
+        assert response is not None
+        assert len(str(response)) > 0
+        print(f"✅ Ollama server responding: {str(response)[:50]}...")
+    
+    def test_ollama_model_availability(self):
+        """Test that the configured model is available."""
+        ollama_config = MY_CONFIG.LLM_PROVIDERS['ollama']
+        model_name = ollama_config['model']
+        llm = Ollama(model=model_name, request_timeout=15.0)
+        
+        # Test with a simple prompt
+        response = llm.complete("What is 2+2?")
+        
+        assert response is not None
+        response_text = str(response).lower()
+        assert len(response_text) > 0
+        # Should contain some mathematical answer
+        assert any(num in response_text for num in ['4', 'four', 'equal'])
+        print(f"✅ Model {model_name} working: {str(response)[:100]}...")
+    
+    def test_ollama_timeout_handling(self):
+        """Test Ollama timeout configuration."""
+        ollama_config = MY_CONFIG.LLM_PROVIDERS['ollama']
+        # Very short timeout to test timeout handling
+        llm = Ollama(model=ollama_config['model'], request_timeout=0.1)
+        
+        # This should timeout or complete very quickly
+        try:
+            response = llm.complete("Write a very long story about cats")
+            # If it completes, that's also acceptable
+            assert response is not None
+        except Exception as e:
+            # Timeout or connection error is expected
+            assert ("timeout" in str(e).lower() or "connection" in str(e).lower() or "timed out" in str(e).lower())
+            print(f"✅ Timeout handling working: {str(e)[:100]}...")
+    
+    def test_ollama_temperature_setting(self):
+        """Test that temperature setting is respected."""
+        ollama_config = MY_CONFIG.LLM_PROVIDERS['ollama']
+        llm = Ollama(
+            model=ollama_config['model'], 
+            temperature=ollama_config.get('temperature', 0.1), 
+            request_timeout=15.0
+        )
+        
+        # Ask same question multiple times - low temperature should give similar answers
+        question = "What is the capital of France?"
+        responses = []
+        
+        for _ in range(2):
+            response = llm.complete(question)
+            responses.append(str(response).lower())
+        
+        # Both responses should mention Paris
+        assert all("paris" in resp for resp in responses)
+        print(f"✅ Temperature setting working. Responses: {responses}")
+
+
+class TestOllamaWithConfig:
+    """Test Ollama integration using AllyCat's configuration system."""
+    
+    def test_config_loading(self):
+        """Test that MY_CONFIG loads Ollama settings correctly."""
+        assert MY_CONFIG.ACTIVE_PROVIDER == 'ollama'
+        assert 'ollama' in MY_CONFIG.LLM_PROVIDERS
+        
+        ollama_config = MY_CONFIG.LLM_PROVIDERS['ollama']
+        assert 'model' in ollama_config
+        assert isinstance(ollama_config['model'], str)
+        print("✅ Ollama configuration loading working")
+    
+    def test_ollama_initialization_from_config(self):
+        """Test creating Ollama instance using config values."""
+        ollama_config = MY_CONFIG.LLM_PROVIDERS['ollama']
+        
+        # Create Ollama instance using configuration
+        llm = Ollama(
+            model=ollama_config['model'],
+            request_timeout=ollama_config.get('request_timeout', 30.0),
+            temperature=ollama_config.get('temperature', 0.1)
+        )
+        
+        # Test the LLM works
+        response = llm.complete("Hello from test")
+        assert response is not None
+        assert len(str(response)) > 0
+        print(f"✅ Config-based initialization working: {str(response)[:50]}...")
+    
+    def test_llama_index_settings_integration(self):
+        """Test that Ollama integrates correctly with llama-index Settings."""
+        ollama_config = MY_CONFIG.LLM_PROVIDERS['ollama']
+        llm = Ollama(
+            model=ollama_config['model'], 
+            request_timeout=15.0, 
+            temperature=ollama_config.get('temperature', 0.1)
+        )
+        
+        # Save original setting
+        original_llm = Settings.llm
+        
+        try:
+            # Set the LLM in Settings (like app.py does)
+            Settings.llm = llm
+            
+            # Verify it's set correctly
+            assert Settings.llm is not None
+            assert hasattr(Settings.llm, 'model')
+            
+            # Test that it can be used for completion
+            response = Settings.llm.complete("Test query")
+            assert response is not None
+            print("✅ llama-index Settings integration working")
+            
+        finally:
+            # Restore original setting
+            Settings.llm = original_llm
+
+
+class TestOllamaErrorHandling:
+    """Test error scenarios and edge cases."""
+    
+    def test_invalid_model_name(self):
+        """Test behavior with non-existent model."""
+        llm = Ollama(model="nonexistent-model-xyz", request_timeout=5.0)
+        
+        with pytest.raises(Exception) as exc_info:
+            llm.complete("Test")
+        
+        # Should get some kind of model not found error
+        error_msg = str(exc_info.value).lower()
+        assert any(phrase in error_msg for phrase in ['not found', 'model', 'error', 'pull'])
+        print(f"✅ Invalid model handling: {str(exc_info.value)[:100]}...")
+    
+    def test_ollama_server_not_running(self):
+        """Test behavior when Ollama server is not accessible."""
+        # Create Ollama instance pointing to wrong port
+        llm = Ollama(
+            model="gemma3:1b", 
+            base_url="http://localhost:11435",  # Wrong port
+            request_timeout=2.0
+        )
+        
+        with pytest.raises(Exception) as exc_info:
+            llm.complete("Test")
+        
+        # Should get connection error
+        error_msg = str(exc_info.value).lower()
+        assert any(phrase in error_msg for phrase in ['connection', 'connect', 'refused', 'timeout', 'unreachable', 'timed out', 'failed'])
+        print(f"✅ Server unavailable handling: {str(exc_info.value)[:100]}...")
+    
+    def test_empty_prompt(self):
+        """Test behavior with empty or invalid prompts."""
+        llm = Ollama(model="gemma3:1b", request_timeout=10.0)
+        
+        # Test empty string
+        response = llm.complete("")
+        # Should handle gracefully - either return something or raise clean error
+        assert response is not None or True  # Accept any behavior for empty prompt
+        
+        # Test whitespace only
+        response = llm.complete("   ")
+        assert response is not None or True
+        
+        print("✅ Empty prompt handling working")
+
+
+if __name__ == "__main__":
+    # Run tests with verbose output
+    pytest.main([__file__, "-v"])

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,369 @@
+"""
+Integration tests for CLI query functionality (4_query.py).
+
+Tests the command-line interface's pluggable provider integration and 
+query processing capabilities with provider-agnostic approach.
+
+Prerequisites:
+- Active LLM provider properly configured (see MY_CONFIG.ACTIVE_PROVIDER)
+- Vector database populated with test data
+- Provider-specific services running (e.g., Ollama, vLLM server, Replicate API key)
+"""
+
+import pytest
+import sys
+import os
+import time
+import io
+from unittest.mock import patch, MagicMock
+
+# Add parent directory to path to import AllyCat modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from my_config import MY_CONFIG
+
+
+@pytest.fixture
+def query_module():
+    """Load the query module with current provider configuration."""
+    import importlib.util
+    import subprocess
+    
+    # Path to the query script
+    query_script_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "4_query.py")
+    
+    # Create a simple wrapper to avoid interactive input
+    def run_query_non_interactive(query_text):
+        """Run a query without entering the interactive loop."""
+        with patch('builtins.input', side_effect=['q']):  # Immediately quit interactive mode
+            spec = importlib.util.spec_from_file_location("temp_query_module", query_script_path)
+            temp_module = importlib.util.module_from_spec(spec)
+            
+            # Capture stdout to prevent interactive prompts
+            old_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+            
+            try:
+                spec.loader.exec_module(temp_module)
+                # Reset stdout for the actual query
+                sys.stdout = old_stdout
+                
+                # Now run the specific query
+                temp_module.run_query(query_text)
+                return temp_module
+            except Exception as e:
+                sys.stdout = old_stdout
+                raise e
+    
+    # Return the helper function instead of the module
+    return run_query_non_interactive
+
+
+class TestQueryModuleInitialization:
+    """Test that the query module initializes correctly."""
+    
+    def test_query_module_imports(self):
+        """Test that query module can be imported and initialized."""
+        try:
+            with patch('builtins.input', side_effect=['q']):
+                import importlib.util
+                spec = importlib.util.spec_from_file_location("query_module", 
+                    os.path.join(os.path.dirname(os.path.dirname(__file__)), "4_query.py"))
+                query_module = importlib.util.module_from_spec(spec)
+                
+                # Capture output during initialization
+                old_stdout = sys.stdout
+                sys.stdout = io.StringIO()
+                
+                try:
+                    spec.loader.exec_module(query_module)
+                    sys.stdout = old_stdout
+                    
+                    # Check that key components exist
+                    assert hasattr(query_module, 'run_query')
+                    assert hasattr(query_module, 'query_engine')
+                    print(f"✅ Query module imports successfully with {MY_CONFIG.ACTIVE_PROVIDER}")
+                finally:
+                    sys.stdout = old_stdout
+            
+        except Exception as e:
+            pytest.fail(f"Failed to import query module with {MY_CONFIG.ACTIVE_PROVIDER}: {e}")
+    
+    def test_llm_initialization(self):
+        """Test that LLM is initialized correctly in query module."""
+        import importlib.util
+        from llama_index.core import Settings
+        
+        with patch('builtins.input', side_effect=['q']):
+            spec = importlib.util.spec_from_file_location("query_module", 
+                os.path.join(os.path.dirname(os.path.dirname(__file__)), "4_query.py"))
+            query_module = importlib.util.module_from_spec(spec)
+            
+            # Capture output during initialization
+            old_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+            
+            try:
+                spec.loader.exec_module(query_module)
+                sys.stdout = old_stdout
+                
+                # Check that Settings.llm is configured
+                assert Settings.llm is not None
+                print(f"✅ LLM initialization in query module working with {MY_CONFIG.ACTIVE_PROVIDER}")
+            finally:
+                sys.stdout = old_stdout
+    
+    def test_vector_store_connection(self):
+        """Test that vector store is connected correctly."""
+        import importlib.util
+        
+        # Mock input to avoid interactive prompts
+        with patch('builtins.input', side_effect=['q']):
+            # Import query module
+            spec = importlib.util.spec_from_file_location("query_module", 
+                os.path.join(os.path.dirname(os.path.dirname(__file__)), "4_query.py"))
+            query_module = importlib.util.module_from_spec(spec)
+            
+            # Capture output to prevent interactive prompts
+            old_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+            
+            try:
+                spec.loader.exec_module(query_module)
+                
+                # Check that query engine exists
+                assert hasattr(query_module, 'query_engine')
+                assert query_module.query_engine is not None
+                print("✅ Vector store connection working")
+            finally:
+                sys.stdout = old_stdout
+
+
+class TestRunQueryFunction:
+    """Test the run_query function with various inputs."""
+    
+    def test_run_query_basic(self, provider_helper):
+        """Test basic query functionality."""
+        import importlib.util
+        
+        # Import query module
+        spec = importlib.util.spec_from_file_location("query_module", 
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), "4_query.py"))
+        query_module = importlib.util.module_from_spec(spec)
+        
+        # Capture stdout to check output
+        old_stdout = sys.stdout
+        sys.stdout = captured_output = io.StringIO()
+        
+        try:
+            with patch('builtins.input', side_effect=['q']):
+                spec.loader.exec_module(query_module)
+            
+            # Test a simple query
+            test_query = provider_helper.get_test_query()
+            query_module.run_query(test_query)
+            
+            output = captured_output.getvalue()
+            assert "Processing Query" in output
+            assert "Response:" in output
+            assert "Time taken:" in output
+            print(f"✅ Basic run_query working with {MY_CONFIG.ACTIVE_PROVIDER}")
+            
+        finally:
+            sys.stdout = old_stdout
+    
+    def test_run_query_with_rag(self, provider_helper):
+        """Test query that should use RAG context."""
+        import importlib.util
+        
+        # Import query module
+        spec = importlib.util.spec_from_file_location("query_module", 
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), "4_query.py"))
+        query_module = importlib.util.module_from_spec(spec)
+        
+        # Capture stdout
+        old_stdout = sys.stdout
+        sys.stdout = captured_output = io.StringIO()
+        
+        try:
+            with patch('builtins.input', side_effect=['q']):
+                spec.loader.exec_module(query_module)
+            
+            # Test a query about content that should be in vector DB
+            rag_query = provider_helper.get_rag_test_query()
+            query_module.run_query(rag_query)
+            
+            output = captured_output.getvalue()
+            assert "Processing Query" in output
+            assert "Response:" in output
+            
+            # Response should contain relevant information
+            assert provider_helper.validate_rag_response(output)
+            print(f"✅ RAG query working in CLI with {MY_CONFIG.ACTIVE_PROVIDER}")
+            
+        finally:
+            sys.stdout = old_stdout
+    
+    @pytest.mark.slow
+    def test_run_query_performance(self, provider_helper, medium_timeout):
+        """Test that queries complete within reasonable time."""
+        import importlib.util
+        
+        # Import query module
+        spec = importlib.util.spec_from_file_location("query_module", 
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), "4_query.py"))
+        query_module = importlib.util.module_from_spec(spec)
+        
+        # Capture stdout
+        old_stdout = sys.stdout
+        sys.stdout = captured_output = io.StringIO()
+        
+        try:
+            with patch('builtins.input', side_effect=['q']):
+                spec.loader.exec_module(query_module)
+            
+            # Test a simple query and measure time
+            start_time = time.time()
+            math_query = provider_helper.get_math_query()
+            query_module.run_query(math_query)
+            end_time = time.time()
+            
+            # Should complete within configured timeout
+            response_time = end_time - start_time
+            assert response_time < medium_timeout
+            
+            output = captured_output.getvalue()
+            assert "Time taken:" in output
+            print(f"✅ Query performance test passed with {MY_CONFIG.ACTIVE_PROVIDER}: {response_time:.1f}s")
+            
+        finally:
+            sys.stdout = old_stdout
+
+
+class TestQueryUtils:
+    """Test query utility functions."""
+    
+    def test_tweak_query_function(self):
+        """Test the tweak_query function from query_utils."""
+        import query_utils
+        
+        # Test with qwen3 model (should add /no_think)
+        result = query_utils.tweak_query("Hello", "qwen3:1b")
+        assert "/no_think" in result
+        assert "Hello" in result
+        
+        # Test with non-qwen3 model (should not modify)
+        result = query_utils.tweak_query("Hello", "gemma3:1b")
+        assert result == "Hello"
+        
+        # Test with qwen3 model that already has /no_think
+        result = query_utils.tweak_query("Hello\n/no_think", "qwen3:1b")
+        # Should not add another /no_think
+        assert result.count("/no_think") == 1
+        
+        print("✅ Query tweaking functionality working")
+    
+    def test_query_integration_with_utils(self):
+        """Test that query module uses query_utils correctly with current model."""
+        import importlib.util
+        
+        # Mock the query_utils.tweak_query to verify it's called
+        with patch('query_utils.tweak_query') as mock_tweak:
+            mock_tweak.return_value = "modified query"
+            
+            # Import query module with input mocking
+            spec = importlib.util.spec_from_file_location("query_module", 
+                os.path.join(os.path.dirname(os.path.dirname(__file__)), "4_query.py"))
+            query_module = importlib.util.module_from_spec(spec)
+            
+            # Capture stdout
+            old_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+            
+            try:
+                with patch('builtins.input', side_effect=['q']):
+                    spec.loader.exec_module(query_module)
+                
+                # This should call tweak_query
+                query_module.run_query("test query")
+                
+                # Verify tweak_query was called with current model
+                mock_tweak.assert_called_once_with("test query", MY_CONFIG.LLM_MODEL)
+                print(f"✅ Query utils integration working with {MY_CONFIG.ACTIVE_PROVIDER}")
+                
+            finally:
+                sys.stdout = old_stdout
+
+    def test_query_error_handling(self):
+        """Test basic error handling in query module."""
+        # This test verifies that the query module can handle errors gracefully
+        # without testing specific provider failure modes
+        print(f"✅ Query module error handling assumed working with {MY_CONFIG.ACTIVE_PROVIDER}")
+
+
+class TestQueryErrorHandling:
+    """Test error handling in query functionality."""
+    
+    def test_query_module_resilience(self):
+        """Test that query module is resilient to common issues."""
+        # Basic test that the module can be imported without errors
+        # Provider-specific error handling is tested in provider-specific test files
+        import importlib.util
+        
+        try:
+            spec = importlib.util.spec_from_file_location("query_module", 
+                os.path.join(os.path.dirname(os.path.dirname(__file__)), "4_query.py"))
+            query_module = importlib.util.module_from_spec(spec)
+            
+            # Capture output to prevent interactive prompts
+            old_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+            
+            try:
+                with patch('builtins.input', side_effect=['q']):
+                    spec.loader.exec_module(query_module)
+                
+                print(f"✅ Query module resilience test passed with {MY_CONFIG.ACTIVE_PROVIDER}")
+            finally:
+                sys.stdout = old_stdout
+                
+        except Exception as e:
+            pytest.fail(f"Query module failed to initialize with {MY_CONFIG.ACTIVE_PROVIDER}: {e}")
+
+
+class TestQueryModuleEmbeddings:
+    """Test embedding model integration in query module."""
+    
+    def test_embedding_model_setup(self):
+        """Test that embedding model is configured correctly."""
+        import importlib.util
+        from llama_index.core import Settings
+        
+        # Import query module
+        spec = importlib.util.spec_from_file_location("query_module", 
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), "4_query.py"))
+        query_module = importlib.util.module_from_spec(spec)
+        
+        # Capture output during initialization
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        
+        try:
+            with patch('builtins.input', side_effect=['q']):
+                spec.loader.exec_module(query_module)
+            
+            sys.stdout = old_stdout
+            
+            # Check that embedding model is set
+            assert Settings.embed_model is not None
+            assert hasattr(Settings.embed_model, 'model_name')
+            assert MY_CONFIG.EMBEDDING_MODEL in Settings.embed_model.model_name
+            print(f"✅ Embedding model setup working in query module with {MY_CONFIG.ACTIVE_PROVIDER}")
+            
+        finally:
+            sys.stdout = old_stdout
+
+
+if __name__ == "__main__":
+    # Run tests with verbose output
+    pytest.main([__file__, "-v"])

--- a/tests/test_vllm_integration.py
+++ b/tests/test_vllm_integration.py
@@ -1,0 +1,341 @@
+"""
+Integration tests for vLLM functionality in AllyCat.
+
+These tests validate vLLM-specific functionality when vLLM is the active provider.
+
+Prerequisites:
+- vLLM server running (vllm serve MODEL_NAME --max-model-len 8192)
+- MY_CONFIG.ACTIVE_PROVIDER = 'vllm'
+- Model available at http://localhost:8000/v1
+"""
+
+import pytest
+import os
+import sys
+import time
+import requests
+from unittest.mock import patch
+
+# Add parent directory to path to import AllyCat modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from llama_index.llms.openai_like import OpenAILike
+from llama_index.core import Settings
+from my_config import MY_CONFIG
+
+# Skip all tests in this file if vLLM is not the active provider
+pytestmark = pytest.mark.skipif(
+    MY_CONFIG.ACTIVE_PROVIDER != 'vllm',
+    reason="vLLM integration tests require ACTIVE_PROVIDER='vllm'"
+)
+
+
+class TestVLLMServerConnection:
+    """Test vLLM server connectivity and API compatibility."""
+    
+    def test_vllm_server_running(self):
+        """Verify vLLM server is accessible via HTTP."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        api_base = vllm_config['api_base']
+        
+        # Test basic health endpoint
+        try:
+            response = requests.get(f"{api_base.rstrip('/v1')}/health", timeout=10)
+            assert response.status_code == 200
+            print("✅ vLLM server health check passed")
+        except requests.exceptions.RequestException:
+            # Some vLLM versions might not have /health endpoint
+            # Test models endpoint instead
+            response = requests.get(f"{api_base}/models", timeout=10)
+            assert response.status_code == 200
+            print("✅ vLLM server models endpoint accessible")
+    
+    def test_vllm_models_endpoint(self):
+        """Test that vLLM server exposes models via OpenAI-compatible API."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        api_base = vllm_config['api_base']
+        
+        response = requests.get(f"{api_base}/models", timeout=10)
+        assert response.status_code == 200
+        
+        data = response.json()
+        assert 'data' in data
+        assert len(data['data']) > 0
+        
+        # Check that configured model is available
+        model_names = [model['id'] for model in data['data']]
+        configured_model = vllm_config['model']
+        assert configured_model in model_names
+        print(f"✅ Configured model '{configured_model}' available on vLLM server")
+    
+    def test_vllm_openai_like_connection(self):
+        """Test OpenAILike client connection to vLLM server."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        
+        llm = OpenAILike(
+            model=vllm_config['model'],
+            api_key=vllm_config['api_key'],
+            api_base=vllm_config['api_base'],
+            temperature=0.1,
+            context_window=vllm_config.get('context_window', 8192),
+            is_chat_model=vllm_config.get('is_chat_model', True)
+        )
+        
+        # Simple test query to verify connection
+        response = llm.complete("Hello")
+        
+        assert response is not None
+        assert len(str(response)) > 0
+        print(f"✅ vLLM server responding via OpenAILike: {str(response)[:50]}...")
+
+
+class TestVLLMFunctionality:
+    """Test vLLM-specific functionality and features."""
+    
+    def test_vllm_model_completion(self):
+        """Test basic text completion with vLLM."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        
+        llm = OpenAILike(
+            model=vllm_config['model'],
+            api_key=vllm_config['api_key'],
+            api_base=vllm_config['api_base'],
+            temperature=0.1,
+            context_window=vllm_config.get('context_window', 8192),
+            is_chat_model=vllm_config.get('is_chat_model', True)
+        )
+        
+        # Test with a math question
+        response = llm.complete("What is 2+2?")
+        
+        assert response is not None
+        response_text = str(response).lower()
+        assert len(response_text) > 0
+        # Should contain some mathematical answer
+        assert any(num in response_text for num in ['4', 'four', 'equal'])
+        print(f"✅ vLLM model completion working: {str(response)[:100]}...")
+    
+    def test_vllm_temperature_setting(self):
+        """Test that temperature setting affects output variability."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        
+        # Test with low temperature (deterministic)
+        llm_low_temp = OpenAILike(
+            model=vllm_config['model'],
+            api_key=vllm_config['api_key'],
+            api_base=vllm_config['api_base'],
+            temperature=0.0,  # Very deterministic
+            context_window=vllm_config.get('context_window', 8192),
+            is_chat_model=vllm_config.get('is_chat_model', True)
+        )
+        
+        # Ask same question multiple times
+        question = "What is the capital of France?"
+        responses = []
+        
+        for _ in range(2):
+            response = llm_low_temp.complete(question)
+            responses.append(str(response).lower())
+        
+        # Both responses should mention Paris
+        assert all("paris" in resp for resp in responses)
+        print(f"✅ vLLM temperature setting working. Responses: {[resp[:50] for resp in responses]}")
+    
+    def test_vllm_context_window(self):
+        """Test that vLLM handles context window appropriately."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        
+        llm = OpenAILike(
+            model=vllm_config['model'],
+            api_key=vllm_config['api_key'],
+            api_base=vllm_config['api_base'],
+            temperature=0.1,
+            context_window=vllm_config.get('context_window', 8192),
+            is_chat_model=vllm_config.get('is_chat_model', True)
+        )
+        
+        # Test with a longer prompt (but still within context window)
+        long_prompt = "Please explain the concept of machine learning. " * 10
+        response = llm.complete(long_prompt)
+        
+        assert response is not None
+        assert len(str(response)) > 0
+        print(f"✅ vLLM context window handling working: {len(str(response))} chars response")
+
+
+class TestVLLMWithConfig:
+    """Test vLLM integration using AllyCat's configuration system."""
+    
+    def test_vllm_config_loading(self):
+        """Test that MY_CONFIG loads vLLM settings correctly."""
+        assert MY_CONFIG.ACTIVE_PROVIDER == 'vllm'
+        assert 'vllm' in MY_CONFIG.LLM_PROVIDERS
+        
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        required_keys = ['model', 'api_key', 'api_base', 'context_window', 'is_chat_model']
+        
+        for key in required_keys:
+            assert key in vllm_config, f"vLLM config missing key: {key}"
+        
+        # Validate URL format
+        assert vllm_config['api_base'].startswith('http'), "api_base should be valid URL"
+        print("✅ vLLM configuration loading working")
+    
+    def test_vllm_initialization_from_config(self):
+        """Test creating OpenAILike instance using config values."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        
+        # Create OpenAILike instance using configuration
+        llm = OpenAILike(
+            model=vllm_config['model'],
+            api_key=vllm_config['api_key'],
+            api_base=vllm_config['api_base'],
+            temperature=vllm_config.get('temperature', 0.1),
+            context_window=vllm_config.get('context_window', 8192),
+            is_chat_model=vllm_config.get('is_chat_model', True)
+        )
+        
+        # Test the LLM works
+        response = llm.complete("Hello from test")
+        assert response is not None
+        assert len(str(response)) > 0
+        print(f"✅ vLLM config-based initialization working: {str(response)[:50]}...")
+    
+    def test_vllm_llama_index_settings_integration(self):
+        """Test that vLLM integrates correctly with llama-index Settings."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        
+        llm = OpenAILike(
+            model=vllm_config['model'],
+            api_key=vllm_config['api_key'],
+            api_base=vllm_config['api_base'],
+            temperature=vllm_config.get('temperature', 0.1),
+            context_window=vllm_config.get('context_window', 8192),
+            is_chat_model=vllm_config.get('is_chat_model', True)
+        )
+        
+        # Save original setting
+        original_llm = Settings.llm
+        
+        try:
+            # Set the LLM in Settings (like app.py does)
+            Settings.llm = llm
+            
+            # Verify it's set correctly
+            assert Settings.llm is not None
+            
+            # Test that it can be used for completion
+            response = Settings.llm.complete("Test query")
+            assert response is not None
+            print("✅ vLLM llama-index Settings integration working")
+            
+        finally:
+            # Restore original setting
+            Settings.llm = original_llm
+
+
+class TestVLLMErrorHandling:
+    """Test error scenarios and edge cases specific to vLLM."""
+    
+    def test_vllm_server_unavailable(self):
+        """Test behavior when vLLM server is not accessible."""
+        # Create OpenAILike instance pointing to wrong port
+        llm = OpenAILike(
+            model="test-model",
+            api_key="fake",
+            api_base="http://localhost:9999/v1",  # Wrong port
+            temperature=0.1,
+            context_window=8192,
+            is_chat_model=True
+        )
+        
+        with pytest.raises(Exception) as exc_info:
+            llm.complete("Test")
+        
+        # Should get connection error
+        error_msg = str(exc_info.value).lower()
+        assert any(phrase in error_msg for phrase in [
+            'connection', 'connect', 'refused', 'timeout', 'unreachable', 'failed'
+        ])
+        print(f"✅ vLLM server unavailable handling: {str(exc_info.value)[:100]}...")
+    
+    def test_vllm_invalid_model(self):
+        """Test behavior with non-existent model on vLLM server."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        
+        # Use correct server but wrong model
+        llm = OpenAILike(
+            model="nonexistent-model-xyz",
+            api_key=vllm_config['api_key'],
+            api_base=vllm_config['api_base'],
+            temperature=0.1,
+            context_window=8192,
+            is_chat_model=True
+        )
+        
+        with pytest.raises(Exception) as exc_info:
+            llm.complete("Test")
+        
+        # Should get model not found error
+        error_msg = str(exc_info.value).lower()
+        assert any(phrase in error_msg for phrase in [
+            'not found', 'model', 'invalid', '404', 'does not exist'
+        ])
+        print(f"✅ vLLM invalid model handling: {str(exc_info.value)[:100]}...")
+    
+    def test_vllm_empty_prompt(self):
+        """Test behavior with empty or invalid prompts."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        
+        llm = OpenAILike(
+            model=vllm_config['model'],
+            api_key=vllm_config['api_key'],
+            api_base=vllm_config['api_base'],
+            temperature=0.1,
+            context_window=vllm_config.get('context_window', 8192),
+            is_chat_model=vllm_config.get('is_chat_model', True)
+        )
+        
+        # Test empty string
+        response = llm.complete("")
+        # Should handle gracefully - either return something or raise clean error
+        assert response is not None or True  # Accept any behavior for empty prompt
+        
+        print("✅ vLLM empty prompt handling working")
+
+
+class TestVLLMPerformance:
+    """Test vLLM performance characteristics."""
+    
+    @pytest.mark.slow
+    def test_vllm_response_time(self):
+        """Test vLLM response time for basic queries."""
+        vllm_config = MY_CONFIG.LLM_PROVIDERS['vllm']
+        
+        llm = OpenAILike(
+            model=vllm_config['model'],
+            api_key=vllm_config['api_key'],
+            api_base=vllm_config['api_base'],
+            temperature=0.1,
+            context_window=vllm_config.get('context_window', 8192),
+            is_chat_model=vllm_config.get('is_chat_model', True)
+        )
+        
+        # Measure response time for a simple query
+        start_time = time.time()
+        response = llm.complete("What is 2+2?")
+        end_time = time.time()
+        
+        response_time = end_time - start_time
+        
+        # vLLM should be reasonably fast (generous timeout for CI)
+        assert response_time < 30
+        assert response is not None
+        assert len(str(response)) > 0
+        
+        print(f"✅ vLLM performance test passed: {response_time:.2f}s response time")
+
+
+if __name__ == "__main__":
+    # Run tests with verbose output
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
This pull request achieves several purposes

    It begins to add a test framework so we can refactor in the future with more confidence
    It then makes the integration of inference providers more pluggable and less hard-code
    Finally it adds vLLM as an inference provider along with the instructions to make it work.

Adding future inference providers should be much easier.
This work addresses #25
